### PR TITLE
Fixed non-repeating background, wrong width of home page and scrollbar

### DIFF
--- a/demo/src/main/webapp/resources/css/bootstrap.css
+++ b/demo/src/main/webapp/resources/css/bootstrap.css
@@ -147,7 +147,7 @@ a:hover {
     text-decoration: underline;
 }
 .row {
-    margin-left: -20px;
+    position: relative;
     *zoom: 1;
 }
 .row:before,
@@ -192,7 +192,7 @@ a:hover {
     width: 380px;
 }
 .span4 {
-    width: 300px;
+    width: 280px;
 }
 .span3 {
     width: 220px;

--- a/demo/src/main/webapp/resources/css/custom.css
+++ b/demo/src/main/webapp/resources/css/custom.css
@@ -4,6 +4,7 @@
 body {
     background: url(../img/bg.png) repeat 0 0 #CCC;
     font-size:13px;
+    min-width:1000px;
 }
 
 a {
@@ -53,7 +54,10 @@ h1 small, h2 small, h3 small, h4 small, h5 small, h6 small {
 .container-fluid {
     width: 940px;
     margin:0 auto;
-    padding:30px 0 10px 30px;
+    padding:30px 0 10px 0;
+}
+.container {
+    width: auto;
 }
 #menu {
     width:auto;
@@ -74,6 +78,11 @@ h1 small, h2 small, h3 small, h4 small, h5 small, h6 small {
 }
 .well {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+}
+
+.github-fork {
+    position: absolute;
+    right: 0;
 }
 
 

--- a/demo/src/main/webapp/resources/css/custom.css
+++ b/demo/src/main/webapp/resources/css/custom.css
@@ -5,6 +5,7 @@ body {
     background: url(../img/bg.png) repeat 0 0 #CCC;
     font-size:13px;
     min-width:1000px;
+    overflow-y:scroll;
 }
 
 a {

--- a/demo/src/main/webapp/resources/templates/desktop/home.html
+++ b/demo/src/main/webapp/resources/templates/desktop/home.html
@@ -1,12 +1,12 @@
 <div class="container well">
     <div class="row">
-        <a href="https://github.com/jboss-jdf/ticket-monster"><img style="float: right;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+        <a class="github-fork" href="https://github.com/jboss-jdf/ticket-monster"><img style="float: right;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
 
         <div class="hero-unit">
 
         <img src="resources/img/splash-ticketmonster.png" width="40%" style="float: left"/>
-        <p><h1 class="special-title">TicketMonster.</h1></p>
-        <p><h1 class="special-title">A JBoss Example.</h1></p>
+        <h1 class="special-title">TicketMonster.</h1>
+        <h1 class="special-title">A JBoss Example.</h1>
         <p>
             TicketMonster is an online ticketing demo application that gets you started with
             JBoss technologies, and helps you learn and evaluate them.


### PR DESCRIPTION
If you access the ticket-monster in a web browser, resize the window and use the bottom scrollbar to move right, you can see that the background is missing. This pull request fixes it + as a side effect it fixes incorrect width of the main page.

The second commit sets the left scrollbar visible always even when it isn't necessary. A lot of other pages do the same (e.g. github), because it looks ugly when the content of the page changes in a way that the scrollbar appears/disappears when it is/isn't needed.
