### PR TITLE
Test issues

### DIFF
--- a/demo/src/test/java/org/jboss/jdf/ticketmonster/test/rest/RESTDeployment.java
+++ b/demo/src/test/java/org/jboss/jdf/ticketmonster/test/rest/RESTDeployment.java
@@ -32,6 +32,8 @@ public class RESTDeployment {
                 .addClass(MediaPath.class)
                 .addClass(MediaManager.class)
                 .addClass(Bootstrap.class)
+                .addClass(BotService.class)
+                .addClass(Bot.class)
                 .addAsLibraries(Maven.resolver()
                         .loadPomFromFile("pom.xml")
                         .resolve("org.infinispan:infinispan-core").withTransitivity().asFile());

--- a/demo/src/test/java/org/jboss/jdf/ticketmonster/test/rest/SearchServiceTest.java
+++ b/demo/src/test/java/org/jboss/jdf/ticketmonster/test/rest/SearchServiceTest.java
@@ -34,7 +34,7 @@ public class SearchServiceTest {
     @Test
     public void testResults() {
         ShowResults results = searchService.search("decade", null, null, null, null);
-        assertEquals(2, results.getResults().size());
+        assertEquals(3, results.getResults().size());
         assertEquals("Rock concert of the decade", results.getResults().iterator().next().getEventName());
         
         // some geo tests
@@ -54,7 +54,7 @@ public class SearchServiceTest {
     @Test
     public void testFaceting() {
         ShowResults results = searchService.search("decade", null, null, null, null);
-        assertEquals(2, results.getResults().size());
+        assertEquals(3, results.getResults().size());
         assertEquals("Rock concert of the decade", results.getResults().iterator().next().getEventName());
         for (FacetGroupView group : results.getFacetGroups()) {
             if (group.getName().equals("category")) {

--- a/demo/src/test/java/org/jboss/jdf/ticketmonster/test/rest/ShowServiceTest.java
+++ b/demo/src/test/java/org/jboss/jdf/ticketmonster/test/rest/ShowServiceTest.java
@@ -81,7 +81,7 @@ public class ShowServiceTest {
         
         List<Show> shows = showService.getAll(queryParameters);
         assertNotNull(shows);
-        assertEquals(2, shows.size());
+        assertEquals(3, shows.size());
         for (Show s: shows) {
             assertEquals("Rock concert of the decade", s.getEvent().getName());
         }


### PR DESCRIPTION
The updated tests seem to expect 2 results rather than 3. However, I'm pretty sure the expected number of results is 3. Try the following to see the three 'shows' being added to the DB:

```
cat demo/src/main/resources/import.sql| grep "event_id, venue_id) values ( 1,"
    insert into Show ( event_id, venue_id) values ( 1, 1);
    insert into Show ( event_id, venue_id) values ( 1, 2);
    insert into Show ( event_id, venue_id) values ( 1, 5);
```

Note: "'Rock concert of the decade'" is the first event and gets PK of '1'.

I could be missing something of course. Maybe one of these shows was intended to be removed at some place in the application that I am missing?

I also added a commit to put some missing classes in the ShrinkWrap deployment. 
