### PR TITLE
Broken url - "Setting up your development environment to use Apache Cordova"

### DIFF
--- a/cordova/README.md
+++ b/cordova/README.md
@@ -21,7 +21,7 @@ For running on an iOS simulator:
 * XCode 6.0 or higher, with iOS 6 SDK or higher.
 * An iOS 5.x or higher simulator for the iPhone or iPad.
 
-If you need more detailed instruction to setup a iOS Development Environment with Apache Cordova, you can take a look at [Setting up your development environment to use Apache Cordova](http://aerogear.org/docs/guides/CordovaSetup/)
+If you need more detailed instruction to setup a iOS Development Environment with Apache Cordova, you can take a look at [Setting up your development environment to use Apache Cordova](https://aerogear.org/docs/guides/aerogear-cordova/CordovaSetup/)
 
 Import the ticket-monster Code
 ------------------------------


### PR DESCRIPTION
I think the url address is changed so it does not work now.

The url of "Setting up your development environment to use Apache Cordova" is changed to https://aerogear.org/docs/guides/aerogear-cordova/CordovaSetup/
