### PR TITLE
CONTRIBUTING.md: add asciidoctor as a dependency

### DIFF
--- a/tutorial/CONTRIBUTING.md
+++ b/tutorial/CONTRIBUTING.md
@@ -6,5 +6,6 @@ Each section of the tutorial is contained in a `.asciidoc` file in this git repo
 * [AsciiDoc](http://www.methods.co.nz/asciidoc/index.html) installed. It's available via most major packaging systems (e.g. Debian, Fedora Extra, MacPorts), and has a Windows installer.
 * You'll also need pygments for syntax highlighting. It's available as a python egg. Easiest to install via `easy_install` e.g. `sudo easy_install pygments`.
 * dblatex, once again available in most major packaging systems, or as a python egg e.g.  `sudo easy_install dblatex`
+* asciidoctor, also available in most major packaging systems, or as a ruby gem -- as explained at http://asciidoctor.org/docs/install-toolchain/
 
 Once you have installed AsciiDoc, you can build individual sections by invoking `asciidoc -b <output of choice> <section.txt>`. If you want to generate the whole tutorial as html, you can call `./generate-guides.sh`.

--- a/tutorial/JBossDeployment.asciidoc
+++ b/tutorial/JBossDeployment.asciidoc
@@ -179,7 +179,7 @@ mvn clean package jboss-as:deploy -Pmysql -s TICKETMONSTER_MAVEN_PROJECT_ROOT/se
 Just like MySQL, you can deploy TicketMonster to JBoss EAP, making use of a 'real' database like PostgreSQL, instead of the default in-memory H2 database. You can follow the procedure outlined as follows:
 
 . Install the PostgreSQL JBDC driver as a new JBoss module.
-.. Define a new JBoss module named `com.mysql` under the `modules` directory of the JBoss EAP installation. Under the `modules/system/layers/base` directory structure, create a directory named `org`, containing sub-directory named `postgresql`, containing a sub-directory named `main`. Place the PostgreSQL JBDC driver in the `main` directory. Finally, define the module via a `module.xml` file with the following contents:
+.. Define a new JBoss module named `org.postgresql` under the `modules` directory of the JBoss EAP installation. Under the `modules/system/layers/base` directory structure, create a directory named `org`, containing sub-directory named `postgresql`, containing a sub-directory named `main`. Place the PostgreSQL JBDC driver in the `main` directory. Finally, define the module via a `module.xml` file with the following contents:
 +
 .EAP_HOME/system/layers/base/com/mysql/main/module.xml
 ----


### PR DESCRIPTION
If asciidoctor isn't installed, creating the tutorials through generate-guides.sh will give a bunch of error messages. asciidoctor is a necessary dependency, but it isn't mentioned in CONTRIBUTING.md.
